### PR TITLE
Add aggregated account subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Fixes
 
 ### Features
+- yellowstone-grpc-client: add `subscribe_accounts_accumulated` for aggregated account updates
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,8 +5515,10 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 name = "yellowstone-grpc-client"
 version = "8.0.0"
 dependencies = [
+ "async-stream",
  "bytes",
  "futures",
+ "solana-pubkey",
  "thiserror 1.0.69",
  "tokio",
  "tonic",

--- a/yellowstone-grpc-client/Cargo.toml
+++ b/yellowstone-grpc-client/Cargo.toml
@@ -17,6 +17,8 @@ thiserror ={ workspace = true }
 tonic = { workspace = true, features = ["tls", "tls-roots"] }
 tonic-health = { workspace = true }
 yellowstone-grpc-proto = { workspace = true, features = ["tonic", "tonic-compression"] }
+async-stream = "0.3"
+solana-pubkey = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
## Summary
- add `subscribe_accounts_accumulated` helper in the Rust client
- expose new dependencies for the client crate
- document the new method in CHANGELOG
- refine the method to accept `Vec<Pubkey>` and cleanup formatting

## Testing
- `cargo check -p yellowstone-grpc-client`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_b_68740572e088832cae171b6b8b8fced3